### PR TITLE
GDAES-4519 moved selinux commands to spec

### DIFF
--- a/nginx.spec
+++ b/nginx.spec
@@ -63,7 +63,6 @@ Source8: nginx.service
 Source9: nginx.upgrade.sh
 Source10: headers-more-nginx-module
 Source11: ngx-fancyindex
-Source12: nginx_ajp_module
 Source13: nginx-xslt-html-parser.patch
 Source14: nginx-auth-ldap
 Source15: nginx-http-shibboleth
@@ -78,8 +77,7 @@ Source23: set-misc-nginx-module
 Source24: ngx_http_consistent_hash
 Source25: nginx.te
 Source26: nginx.pp
-Source27: passenger
-Source28: passenger.conf
+
 
 License: 2-clause BSD-like license
 
@@ -94,17 +92,6 @@ BuildRequires: pam-devel
 BuildRequires: selinux-policy-targeted
 Requires: policycoreutils
 
-# Begin Passenger module requires
-BuildRequires: libcurl-devel
-BuildRequires: httpd-devel
-BuildRequires: libev-devel >= 4.0.0
-BuildRequires: ruby
-BuildRequires: ruby-devel
-BuildRequires: rubygems
-BuildRequires: rubygems-devel
-# BuildRequires: rubygem(rake) >= 0.8.1
-# BuildRequires: rubygem(rack)
-# End Passenger module build requirements
 
 Provides: webserver
 
@@ -131,7 +118,6 @@ Selinux policy for nginx when set to enforcing
 %setup -q
 cp -R -p %SOURCE10 .
 cp -R -p %SOURCE11 .
-cp -R -p %SOURCE12 .
 patch -p1 < %SOURCE13
 cp -R -p %SOURCE14 .
 cp -R -p %SOURCE15 .
@@ -145,7 +131,6 @@ cp -R -p %SOURCE22 .
 cp -R -p %SOURCE23 .
 cp -R -p %SOURCE24 .
 cp -R -p %SOURCE25 .
-cp -R -p %SOURCE27 .
 
 %build
 ./configure \
@@ -186,7 +171,6 @@ cp -R -p %SOURCE27 .
         --with-http_spdy_module \
         --with-http_xslt_module \
         --add-module=%{_builddir}/%{name}-%{version}/ngx-fancyindex \
-        --add-module=%{_builddir}/%{name}-%{version}/nginx_ajp_module \
         --add-module=%{_builddir}/%{name}-%{version}/headers-more-nginx-module \
         --add-module=%{_builddir}/%{name}-%{version}/nginx-auth-ldap \
         --add-module=%{_builddir}/%{name}-%{version}/nginx-http-shibboleth \
@@ -203,7 +187,7 @@ cp -R -p %SOURCE27 .
 	--add-module=%{_builddir}/%{name}-%{version}/set-misc-nginx-module \
 	--add-module=%{_builddir}/%{name}-%{version}/ngx_http_consistent_hash \
 	--add-module=%{_builddir}/%{name}-%{version}/ngx_http_auth_pam_module \
-    --add-module=%{_builddir}/%{name}-%{version}/passenger/src/nginx_module \
+
         $*
 make %{?_smp_mflags}
 %{__mv} %{_builddir}/%{name}-%{version}/objs/nginx \
@@ -245,7 +229,6 @@ make %{?_smp_mflags}
         --with-http_spdy_module \
         --with-http_xslt_module \
         --add-module=%{_builddir}/%{name}-%{version}/ngx-fancyindex \
-        --add-module=%{_builddir}/%{name}-%{version}/nginx_ajp_module \
         --add-module=%{_builddir}/%{name}-%{version}/headers-more-nginx-module \
         --add-module=%{_builddir}/%{name}-%{version}/nginx-auth-ldap \
         --add-module=%{_builddir}/%{name}-%{version}/nginx-http-shibboleth \
@@ -262,7 +245,7 @@ make %{?_smp_mflags}
         --add-module=%{_builddir}/%{name}-%{version}/set-misc-nginx-module \
         --add-module=%{_builddir}/%{name}-%{version}/ngx_http_consistent_hash \
         --add-module=%{_builddir}/%{name}-%{version}/ngx_http_auth_pam_module \
-        --add-module=%{_builddir}/%{name}-%{version}/passenger/src/nginx_module \
+
         $*
 make %{?_smp_mflags}
 
@@ -291,8 +274,7 @@ semodule_package -o %SOURCE26 -m nginx.mod
    $RPM_BUILD_ROOT%{_sysconfdir}/nginx/conf.d/default.conf.sample
 %{__install} -m 644 -p %{SOURCE6} \
    $RPM_BUILD_ROOT%{_sysconfdir}/nginx/conf.d/example_ssl.conf.sample
-%{__install} -m 644 -p %{SOURCE28} \
-   $RPM_BUILD_ROOT%{_sysconfdir}/nginx/conf.d/passenger.conf
+
 
 %{__mkdir} -p $RPM_BUILD_ROOT%{_sysconfdir}/sysconfig
 %{__install} -m 644 -p %{SOURCE3} \
@@ -342,7 +324,7 @@ install -p -m 644 -D %{SOURCE26} \
 %config(noreplace) %{_sysconfdir}/nginx/nginx.conf
 %config(noreplace) %{_sysconfdir}/nginx/conf.d/default.conf.sample
 %config(noreplace) %{_sysconfdir}/nginx/conf.d/example_ssl.conf.sample
-%config(noreplace) %{_sysconfdir}/nginx/conf.d/passenger.conf
+
 %config(noreplace) %{_sysconfdir}/nginx/mime.types
 %config(noreplace) %{_sysconfdir}/nginx/fastcgi_params
 %config(noreplace) %{_sysconfdir}/nginx/scgi_params
@@ -424,6 +406,8 @@ BANNER
 fi
 %post policy
 semodule -i %{_datadir}/selinux/packages/nginx/nginx.pp 2>/dev/null ||:
+setsebool -P httpd_can_network_connect on 2>/dev/null ||:
+setsebool -P httpd_can_network_relay on 2>/dev/null ||:
 
 %preun
 if [ $1 -eq 0 ]; then
@@ -452,6 +436,8 @@ fi
 
 %postun policy 
 semodule -i %{_datadir}/selinux/packages/nginx/nginx.pp 2>/dev/null || :
+setsebool -P httpd_can_network_connect on 2>/dev/null ||:
+setsebool -P httpd_can_network_relay on 2>/dev/null ||:
 
 %changelog
 * Tue Sep 16 2014 Sergey Budnevitch <sb@nginx.com>

--- a/nginx.te
+++ b/nginx.te
@@ -2,9 +2,21 @@ module nginx 1.0;
 
 require {
 	type httpd_t;
+	type http_cache_port_t;
+	type puppet_port_t;
 	type httpd_config_t;
+	type httpd_port_t;
+	type http_port_t;
+	type hostname_t;
+	type transproxy_port_t;
+	type inotifyfs_t;
+	class tcp_socket name_connect;
+	class dir read;
 	class dir { write create add_name setattr };
 }
+
+#============= hostname_t ==============
+allow hostname_t inotifyfs_t:dir read;
 
 #============= httpd_t ==============
 #!!!! The source type 'httpd_t' can write to a 'dir' of the following types:
@@ -14,4 +26,8 @@ allow httpd_t httpd_config_t:dir write;
 
 #!!!! This avc is allowed in the current policy
 allow httpd_t httpd_config_t:dir { create add_name setattr };
+allow httpd_t transproxy_port_t:tcp_socket name_connect;
 
+allow httpd_t http_cache_port_t:tcp_socket name_connect;
+allow httpd_t puppet_port_t:tcp_socket name_connect;
+allow httpd_t usr_t:sock_file write;


### PR DESCRIPTION
so we can work around having to execute them in chef.
also removed ajp and passenger modules
also added some rules selinux is going to need to type enforcement
