### PR TITLE
PAAS-234 fixing Build dependencies for ruby 2.2

### DIFF
--- a/nginx.spec
+++ b/nginx.spec
@@ -100,10 +100,11 @@ Requires: policycoreutils
 BuildRequires: libcurl-devel
 BuildRequires: httpd-devel
 BuildRequires: libev-devel >= 4.0.0
-BuildRequires: ruby
-BuildRequires: ruby-devel
-BuildRequires: rubygems
-BuildRequires: rubygems-devel
+BuildRequires: ruby >= 2.2.5
+# These should be obsoleted in 2.2.5
+# BuildRequires: ruby-devel
+# BuildRequires: rubygems
+# BuildRequires: rubygems-devel
 %endif
 
 Provides: webserver


### PR DESCRIPTION
ruby-devel & rubygems are now included in ruby.
